### PR TITLE
templating-stack: rename, add destination_is_file to templating configs

### DIFF
--- a/stack-templating/.cycloid.yml
+++ b/stack-templating/.cycloid.yml
@@ -1,7 +1,7 @@
 # Configuration of the Cycloid stack
 version: '2'
-name: 'templating-stack'
-canonical: 'templating-stack'
+name: 'stack-templating'
+canonical: 'stack-templating'
 status: 'public'
 description: 'Used to execute kubernetes template files.'
 keywords:
@@ -23,6 +23,8 @@ config:
       - paths:
         - templating/source-templates/deployment.yaml.tmpl
         destination: templating/result/template-files/deployment.yaml
+        config:
+          destination_is_file: true
       - paths:
         - templating/source-templates/dir1/service.yaml.tmpl
         destination: templating/result/template-files
@@ -35,6 +37,10 @@ config:
       - paths:
         - templating/source-templates
         destination: templating/result/template-dir/onefile/manifest.yaml
+        config:
+          destination_is_file: true
       - paths:
         - templating/source-templates
         destination: templating/result/template-dir/tree
+        config:
+          destination_is_file: false

--- a/stack-templating/templating/source-templates/deployment.yaml.tmpl
+++ b/stack-templating/templating/source-templates/deployment.yaml.tmpl
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx: {{ .nginx.image_tag }}
+        image: nginx:{{ .nginx.image_tag }}
         ports:
         - containerPort: {{ .nginx.container_port }}

--- a/stack-templating/templating/source-templates/dir1/dir2/pod.yaml.tmpl
+++ b/stack-templating/templating/source-templates/dir1/dir2/pod.yaml.tmpl
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx: {{ .nginx.image_tag }}
+    image: nginx:{{ .nginx.image_tag }}
     ports:
     - containerPort: {{ .nginx.container_port }}


### PR DESCRIPTION
Renamed to reflect the directory name to avoid confusion. 
Added config with destination_is_file param to explicitly specify whether the destination is a directory or a merged file.