### PR TITLE
Migrate stackforms fixtures off v1/v2 on stacks (BE-1486)

### DIFF
--- a/stack-dummy/.forms.yml
+++ b/stack-dummy/.forms.yml
@@ -1,10 +1,15 @@
 ---
-default:
-  pipeline:
-    config:
-      - name: "Message"
-        description: "Message to display in the job"
-        key: message
-        widget: simple_text
-        type: string
-        default: "hello world and especially to ($ organization_canonical $)"
+use_cases:
+  - name: default
+    sections:
+      - name: pipeline
+        groups:
+          - name: config
+            technologies: [pipeline]
+            vars:
+              - name: "Message"
+                description: "Message to display in the job"
+                key: message
+                widget: simple_text
+                type: string
+                default: "hello world and especially to ($ organization_canonical $)"

--- a/wordpress-multicloud-demo/.forms.yml
+++ b/wordpress-multicloud-demo/.forms.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 use_cases:
   - name: cycloid-common
     sections:


### PR DESCRIPTION
Part of dropping stackforms v1/v2 support (BE-1486). youdeploy-http-api no longer parses v1 (nested-map) forms (they now load empty) and ignores the v2 `version:` field.

Changes:
- **stack-dummy/.forms.yml**: convert v1 nested-map → v3 `use_cases:` (**required** — consumed by `ci_pipelines_test.go` / `service_catalog_sources_test.go`, was loading empty)
- **wordpress-multicloud-demo/.forms.yml**: drop the now-meaningless `version: 2` line (tidy-up)

Conversion mirrors the old `MutateV1ToV2`: usecase→`use_cases[].name`, tech→`sections[].name`, group→`groups[].name` with `technologies: [<section>]`, entities→`vars:`.