### PR TITLE
Migrate stackforms fixtures off v1/v2 on gt-add-v3-stack (BE-1486)

### DIFF
--- a/stack-dummy-v3/.forms.yml
+++ b/stack-dummy-v3/.forms.yml
@@ -1,10 +1,15 @@
 ---
-default:
-  pipeline:
-    config:
-      - name: "Message"
-        description: "Message to display in the job"
-        key: message
-        widget: simple_text
-        type: string
-        default: "hello world and especially to ($ organization_canonical $)"
+use_cases:
+  - name: default
+    sections:
+      - name: pipeline
+        groups:
+          - name: config
+            technologies: [pipeline]
+            vars:
+              - name: "Message"
+                description: "Message to display in the job"
+                key: message
+                widget: simple_text
+                type: string
+                default: "hello world and especially to ($ organization_canonical $)"

--- a/stack-dummy/.forms.yml
+++ b/stack-dummy/.forms.yml
@@ -1,10 +1,15 @@
 ---
-default:
-  pipeline:
-    config:
-      - name: "Message"
-        description: "Message to display in the job"
-        key: message
-        widget: simple_text
-        type: string
-        default: "hello world and especially to ($ organization_canonical $)"
+use_cases:
+  - name: default
+    sections:
+      - name: pipeline
+        groups:
+          - name: config
+            technologies: [pipeline]
+            vars:
+              - name: "Message"
+                description: "Message to display in the job"
+                key: message
+                widget: simple_text
+                type: string
+                default: "hello world and especially to ($ organization_canonical $)"

--- a/wordpress-multicloud-demo/.forms.yml
+++ b/wordpress-multicloud-demo/.forms.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 use_cases:
   - name: cycloid-common
     sections:


### PR DESCRIPTION
Part of dropping stackforms v1/v2 support (BE-1486).

Changes:
- **stack-dummy/.forms.yml**: convert v1 nested-map → v3 `use_cases:` (**required** for e2e, was loading empty)
- **stack-dummy-v3/.forms.yml**: convert v1 nested-map → v3 `use_cases:`
- **wordpress-multicloud-demo/.forms.yml**: drop the now-meaningless `version: 2` line

Conversion mirrors the old `MutateV1ToV2` mapping.