### PR TITLE
Migrate stackforms fixtures off v1/v2 on stacksv2 (BE-1486)

### DIFF
--- a/stack-magentov2/.forms.yml
+++ b/stack-magentov2/.forms.yml
@@ -1,157 +1,213 @@
-first-usecase:
-  pipeline:
-    group1:
-    - widget: "text_area"
-      default: "nobucket"
-      type: "string"
-      description: "Bucket used to store magento code"
-      key: "magento_deploy_bucket_name"
-      name: "The bucket used"
-    - widget: "text_area"
-      type: "string"
-      description: "Doesn't matter"
-      key: "no-exist"
-      name: "Some imaginary var"
-  terraform:
-    group2:
-    - widget: "text_area"
-      type: "boolean"
-      key: "rds_multiaz"
-      name: "RDS multi-AZ"
-      required: true
-    - widget: "slider_range"
-      type: "integer"
-      default: 2
-      values: [1, 10]
-      key: "rds_backup_retention"
-      name: "Backup retention"
-      required: true
-    - widget: "number"
-      type: "integer"
-      key: "front_count"
-      name: "Front amount"
-      required: true
-    - widget: "text_area"
-      type: "array"
-      description: "List of public network IDs"
-      key: "public_subnets_ids"
-      name: "Pub nets"
-    - widget: "text_area"
-      type: "string"
-      description: "The VPC ID to run the project"
-      key: "vpc_id"
-      name: "VPC ID"
-    - widget: "slider_list"
-      required: true
-      default: "XS"
-      unit: "($, GHz, GB)"
-      type: "map"
-      values: [{label: XS, value: t3.micro}, {label: S, value: t3.small}, {label: M, value: t3.medium}, {label: L, value: t3.large}]
-      description: ""
-      key: "instance_type"
-      name: "mapped variable"
-      quota_config:
-        mapping:
-          t3.micro: "2 cpu, 2 memory"
-          t3.small: "3 cpu, 3 memory"
-          t3.medium: "3 cpu, 3 memory"
-          t3.large: "4 cpu, 4 memory"
-        count_ref: "front_count"
-    - widget: "number"
-      type: "integer"
-      key: "storage"
-      name: "Front storage"
-      quota_config:
-        type: "storage"
-        count_ref: "front_count"
-    - widget: "cy_inventory_resource"
-      type: "integer"
-      key: "inventory_test"
-      name: "Inventory test"
-      widget_config:
-        attribute: "id"
-        filters:
-          type: "aws_vpc"
-    - widget: "cy_inventory_output"
-      type: "string"
-      key: "inventory_output_test"
-      name: "Instance IP address for output test"
-      widget_config:
-        filters:
-          keys: ["instance_public_ip", "instance_private_ip"]
-    - widget: "dropdown"
-      values: [{label: "EU West 1", value: "eu-west-1"},{label: "EU West 2", value: "eu-west-2"}]
-      type: "map"
-      name: "Magento Map"
-      key: "region"
-      required: true
-      default: "EU West 1"
-    - widget: "dropdown"
-      type: "map"
-      key: "interpolated_cy_values_ref"
-      name: "Inventory test"
-      default: '1a'
-      values: 
-        - {label: '1a', value: 'vpc-1-a'}
-        - {label: '1b', value: 'vpc-1-b'}
-      values_ref: "https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?owner=($ project_owner_canonical $)"
-    - widget: "dropdown"
-      type: "map"
-      key: "interpolated_sf_values_ref"
-      name: "Inventory test"
-      default: '1a'
-      values: 
-        - {label: '1a', value: 'vpc-1-a'}
-        - {label: '1b', value: 'vpc-1-b'}
-      values_ref: "https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?storage=${storage}"
-    - widget: "dropdown"
-      type: "array"
-      key: "interpolated_sf_multi_values_ref"
-      name: "Inventory test"
-      values_ref: "https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?region=${region}"
-      widget_config:
-        multiselect: true
-    - widget: "dropdown"
-      type: "string"
-      key: "interpolated_condition"
-      name: "Inventory test condition"
-      values:
-        options:
-          - condition: "'($ project_owner_canonical $)' == 'robert_parkin'"
-            values: ["8.0", "5.7"]
-          - condition: "'($ project_owner_canonical $)' != 'robert_parkin'"
-            values: ["13", "14", "15"]
-  terragrunt:
-    group3:
-    - widget: "simple_text"
-      default: ""
-      type: "string"
-      description: "The TG region"
-      key: "tg_region"
-      name: "TG Region"
-second-usecase:
-  ansible:
-    groupY:
-    - widget: "dropdown"
-      values: [{foo: bar}, {bar: foo}]
-      type: "map"
-      name: "Magento Map"
-      key: "magento_map"
-      required: true
-  terraform:
-    groupX:
-    - widget: "simple_text"
-      default: ""
-      type: "string"
-      description: "The DB password for Magento"
-      key: "rds_password"
-      name: "RDS password"
-imaginary-use-case:
-  ansible:
-    group1:
-    - widget: "simple_text"
-      default: "don't matter"
-      type: "string"
-      description: "Some stuff"
-      key: "var"
-      name: "var with imaginary friends"
+---
+use_cases:
+- name: first-usecase
+  sections:
+  - name: pipeline
+    groups:
+    - name: group1
+      technologies:
+      - pipeline
+      vars:
+      - widget: text_area
+        default: nobucket
+        type: string
+        description: Bucket used to store magento code
+        key: magento_deploy_bucket_name
+        name: The bucket used
+      - widget: text_area
+        type: string
+        description: Doesn't matter
+        key: no-exist
+        name: Some imaginary var
+  - name: terraform
+    groups:
+    - name: group2
+      technologies:
+      - terraform
+      vars:
+      - widget: text_area
+        type: boolean
+        key: rds_multiaz
+        name: RDS multi-AZ
+        required: true
+      - widget: slider_range
+        type: integer
+        default: 2
+        values:
+        - 1
+        - 10
+        key: rds_backup_retention
+        name: Backup retention
+        required: true
+      - widget: number
+        type: integer
+        key: front_count
+        name: Front amount
+        required: true
+      - widget: text_area
+        type: array
+        description: List of public network IDs
+        key: public_subnets_ids
+        name: Pub nets
+      - widget: text_area
+        type: string
+        description: The VPC ID to run the project
+        key: vpc_id
+        name: VPC ID
+      - widget: slider_list
+        required: true
+        default: XS
+        unit: ($, GHz, GB)
+        type: map
+        values:
+        - label: XS
+          value: t3.micro
+        - label: S
+          value: t3.small
+        - label: M
+          value: t3.medium
+        - label: L
+          value: t3.large
+        description: ''
+        key: instance_type
+        name: mapped variable
+        quota_config:
+          mapping:
+            t3.micro: 2 cpu, 2 memory
+            t3.small: 3 cpu, 3 memory
+            t3.medium: 3 cpu, 3 memory
+            t3.large: 4 cpu, 4 memory
+          count_ref: front_count
+      - widget: number
+        type: integer
+        key: storage
+        name: Front storage
+        quota_config:
+          type: storage
+          count_ref: front_count
+      - widget: cy_inventory_resource
+        type: integer
+        key: inventory_test
+        name: Inventory test
+        widget_config:
+          attribute: id
+          filters:
+            type: aws_vpc
+      - widget: cy_inventory_output
+        type: string
+        key: inventory_output_test
+        name: Instance IP address for output test
+        widget_config:
+          filters:
+            keys:
+            - instance_public_ip
+            - instance_private_ip
+      - widget: dropdown
+        values:
+        - label: EU West 1
+          value: eu-west-1
+        - label: EU West 2
+          value: eu-west-2
+        type: map
+        name: Magento Map
+        key: region
+        required: true
+        default: EU West 1
+      - widget: dropdown
+        type: map
+        key: interpolated_cy_values_ref
+        name: Inventory test
+        default: 1a
+        values:
+        - label: 1a
+          value: vpc-1-a
+        - label: 1b
+          value: vpc-1-b
+        values_ref: https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?owner=($ project_owner_canonical $)
+      - widget: dropdown
+        type: map
+        key: interpolated_sf_values_ref
+        name: Inventory test
+        default: 1a
+        values:
+        - label: 1a
+          value: vpc-1-a
+        - label: 1b
+          value: vpc-1-b
+        values_ref: https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?storage=${storage}
+      - widget: dropdown
+        type: array
+        key: interpolated_sf_multi_values_ref
+        name: Inventory test
+        values_ref: https://devs-testing-bucket.s3.eu-west-1.amazonaws.com/backend/values_ref.json?region=${region}
+        widget_config:
+          multiselect: true
+      - widget: dropdown
+        type: string
+        key: interpolated_condition
+        name: Inventory test condition
+        values:
+          options:
+          - condition: '''($ project_owner_canonical $)'' == ''robert_parkin'''
+            values:
+            - '8.0'
+            - '5.7'
+          - condition: '''($ project_owner_canonical $)'' != ''robert_parkin'''
+            values:
+            - '13'
+            - '14'
+            - '15'
+  - name: terragrunt
+    groups:
+    - name: group3
+      technologies:
+      - terragrunt
+      vars:
+      - widget: simple_text
+        default: ''
+        type: string
+        description: The TG region
+        key: tg_region
+        name: TG Region
+- name: second-usecase
+  sections:
+  - name: ansible
+    groups:
+    - name: groupY
+      technologies:
+      - ansible
+      vars:
+      - widget: dropdown
+        values:
+        - foo: bar
+        - bar: foo
+        type: map
+        name: Magento Map
+        key: magento_map
+        required: true
+  - name: terraform
+    groups:
+    - name: groupX
+      technologies:
+      - terraform
+      vars:
+      - widget: simple_text
+        default: ''
+        type: string
+        description: The DB password for Magento
+        key: rds_password
+        name: RDS password
+- name: imaginary-use-case
+  sections:
+  - name: ansible
+    groups:
+    - name: group1
+      technologies:
+      - ansible
+      vars:
+      - widget: simple_text
+        default: don't matter
+        type: string
+        description: Some stuff
+        key: var
+        name: var with imaginary friends

--- a/wordpress-multicloud-demo/.forms.yml
+++ b/wordpress-multicloud-demo/.forms.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 use_cases:
   - name: cycloid-common
     sections:


### PR DESCRIPTION
Part of dropping stackforms v1/v2 support (BE-1486). v1 nested-map forms now load empty and the v2 `version:` field is ignored.

Changes:
- **stack-magentov2/.forms.yml**: convert v1 nested-map → v3 `use_cases:` (tidy-up — not referenced by Go e2e tests, but makes the fixture functional again)
- **wordpress-multicloud-demo/.forms.yml**: drop the now-meaningless `version: 2` line

Conversion mirrors the old `MutateV1ToV2`: usecase→`use_cases[].name`, tech→`sections[].name`, group→`groups[].name` with `technologies: [<section>]`, entities→`vars:`.