### PR TITLE
Drop meaningless stackforms version: line on aj-BE-995 (BE-1486)

### DIFF
--- a/stack-templating-sharing/.forms.yml
+++ b/stack-templating-sharing/.forms.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 use_cases:
   - name: tech-sharing
     sections:

--- a/stack-templating/.forms.yml
+++ b/stack-templating/.forms.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 use_cases:
   - name: template-files
   - name: template-dir


### PR DESCRIPTION
Part of dropping stackforms v1/v2 support (BE-1486). The v2 `version:` field is now ignored.

Changes:
- **stack-templating/.forms.yml** and **stack-templating-sharing/.forms.yml**: drop the now-meaningless `version: 2` line. Both forms are already v3-shaped (`use_cases:`), so this is a pure tidy-up — no behaviour change.