### PR TITLE
Drop meaningless stackforms version: line on siemens (BE-1486)

### DIFF
--- a/siemens-chamber-bbb-prd/.forms.yml
+++ b/siemens-chamber-bbb-prd/.forms.yml
@@ -1,4 +1,3 @@
-version: 2
 
 # Define the stack configuration form and organize inputs of various types into sections and groups.
 # See: https://docs.staging.cycloid.io/deploy/stackforms/file-format.html

--- a/siemens-chamber-ccc-prd-dev/.forms.yml
+++ b/siemens-chamber-ccc-prd-dev/.forms.yml
@@ -1,4 +1,3 @@
-version: 2
 
 # Define the stack configuration form and organize inputs of various types into sections and groups.
 # See: https://docs.staging.cycloid.io/deploy/stackforms/file-format.html

--- a/stack-chamber-manager/.forms.yml
+++ b/stack-chamber-manager/.forms.yml
@@ -1,5 +1,3 @@
-# Use the latest version 2 of the Cycloid StackForms engine.
-version: 2
 
 use_cases:
 - name: cycloid-common

--- a/stack-chamber-manager/chamber-stack-template/.forms.yml
+++ b/stack-chamber-manager/chamber-stack-template/.forms.yml
@@ -1,4 +1,3 @@
-version: 2
 
 # Define the stack configuration form and organize inputs of various types into sections and groups.
 # See: https://docs.staging.cycloid.io/deploy/stackforms/file-format.html


### PR DESCRIPTION
Part of dropping stackforms v1/v2 support (BE-1486). The v2 `version:` field is now ignored.

Changes — drop the now-meaningless `version: 2` line (forms are already v3-shaped, `use_cases:`):
- siemens-chamber-bbb-prd/.forms.yml
- siemens-chamber-ccc-prd-dev/.forms.yml
- stack-chamber-manager/.forms.yml (also removes the stale "use the latest version 2" comment)
- stack-chamber-manager/chamber-stack-template/.forms.yml

Pure tidy-up — no behaviour change.