### PR TITLE
Add stack labels on stacksv4 (PROD-770)

### DIFF
--- a/simpletfv4/.cycloid.yml
+++ b/simpletfv4/.cycloid.yml
@@ -7,6 +7,9 @@ description: "The bare minimum files to build your stack from scratch."
 image: https://github.com/cycloidio/bootstrap-stacks/blob/master/blank-sample/thumbnail.png
 template: false
 status: "public"
+# Labels used by the youdeploy-http-api label filter / env-type selector e2e tests (PROD-770)
+labels:
+  env-type: staging
 # Add use cases to the stack.
 # See: https://docs.cycloid.io/manage/pipeline/multi-use-case.html#multiple-use-case
 config:

--- a/simplev4/.cycloid.yml
+++ b/simplev4/.cycloid.yml
@@ -7,6 +7,10 @@ description: 'The bare minimum files to build your stack from scratch.'
 image: https://github.com/cycloidio/bootstrap-stacks/blob/master/blank-sample/thumbnail.png
 template: false
 status: 'public'
+# Labels used by the youdeploy-http-api label filter / env-type selector e2e tests (PROD-770)
+labels:
+  env-type: [production, staging]
+  tier: backend
 # Add use cases to the stack.
 # See: https://docs.cycloid.io/manage/pipeline/multi-use-case.html#multiple-use-case
 config:


### PR DESCRIPTION
## What
Add a `labels:` block to two stacks on the `stacksv4` fixture branch so the youdeploy-http-api e2e tests for stack labels can run against real fixtures instead of seeding rows into `service_catalog_labels` directly.

- `simplev4`: `env-type: [production, staging]`, `tier: backend` (multi-value + multi-key)
- `simpletfv4`: `env-type: staging`
- `interpolator-test`: left unlabeled (control)

## Why
PROD-770 adds key:value labels to stacks (authored only in `.cycloid.yml`) plus a label filter on the service-catalogs list. The e2e tests need label-bearing fixture stacks; today they seed labels into the DB, which we want to drop.

## Notes
- Labels-only change: no stacks added/removed, so existing stack-count assertions are unaffected.
- Requires the `cycloid/backend-tests-git-server` image to be rebuilt/published from this branch for the youdeploy-http-api tests to pick the labels up.
- Follow-up in youdeploy-http-api (PROD-770): drop the DB seeds and assert against these fixture labels.